### PR TITLE
Add non-blocking timer module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 #![feature(const_fn)]
 #![allow(non_camel_case_types)]
 #![feature(never_type)]
+#![feature(duration_extras)]
 
 extern crate bare_metal;
 extern crate cast;
@@ -19,3 +20,4 @@ pub mod i2c;
 pub mod prelude;
 pub mod serial;
 pub mod rng;
+pub mod timer;

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,0 +1,50 @@
+use core::time::Duration;
+use core::u32;
+
+use nb::{Error, Result};
+use hal::timer::{CountDown, Periodic};
+use nrf51::TIMER0;
+
+pub struct Timer(TIMER0);
+
+impl Timer {
+    pub fn new(timer: TIMER0) -> Timer {
+        // 32bits @ 1MHz == max delay of ~1 hour 11 minutes
+        timer.bitmode.write(|w| w.bitmode()._32bit());
+        timer.prescaler.write(|w| unsafe { w.prescaler().bits(4) });
+        timer.intenset.write(|w| w.compare0().set());
+        timer.shorts.write(|w| w.compare0_clear().enabled());
+
+        Timer(timer)
+    }
+}
+
+impl CountDown for Timer {
+    type Time = Duration;
+
+    fn start<T>(&mut self, count: T)
+    where
+        T: Into<Self::Time>,
+    {
+        let duration = count.into();
+        assert!(duration.as_secs() < ((u32::MAX - duration.subsec_micros()) / 1_000_000) as u64);
+
+        let us = (duration.as_secs() as u32) * 1_000_000 + duration.subsec_micros();
+        self.0.cc[0].write(|w| unsafe { w.bits(us) });
+
+        self.0.events_compare[0].reset();
+        self.0.tasks_clear.write(|w| unsafe { w.bits(1) });
+        self.0.tasks_start.write(|w| unsafe { w.bits(1) });
+    }
+
+    fn wait(&mut self) -> Result<(), !> {
+        if self.0.events_compare[0].read().bits() == 1 {
+            self.0.events_compare[0].reset();
+            Ok(())
+        } else {
+            Err(Error::WouldBlock)
+        }
+    }
+}
+
+impl Periodic for Timer {}


### PR DESCRIPTION
As I mentioned in https://github.com/japaric/embedded-hal/issues/59 the `Duration` struct gets compiled out fully in my test code, but I'm still not certain using it is the best idea in case it doesn't.