### PR TITLE
Allow multiple timers in Delay and Timer

### DIFF
--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,82 +1,95 @@
 //! Delays
 
 use cast::u32;
-use nrf51::TIMER0;
+use nrf51::{TIMER0, TIMER1, TIMER2};
 
 use hal::blocking::delay::{DelayMs, DelayUs};
 
 /// System timer `TIMER0` as a delay provider
-pub struct Delay {
-    timer: TIMER0,
+pub struct Delay<TIM> {
+    timer: TIM,
 }
 
-impl Delay {
-    /// Configures the TIMER0 as a delay provider
-    pub fn new(timer: TIMER0) -> Self {
-        timer.tasks_stop.write(|w| unsafe { w.bits(1) });
+macro_rules! delay {
+    ($($TIM:ty),+) => {
+        $(
+            impl Delay<$TIM> {
+                /// Configures the TIMER0 as a delay provider
+                pub fn new(timer: $TIM) -> Self {
+                    timer.tasks_stop.write(|w| unsafe { w.bits(1) });
 
-        // Set counter to 24bit mode
-        timer.bitmode.write(|w| unsafe { w.bits(2) });
+                    // Set counter to 24bit mode
+                    timer.bitmode.write(|w| unsafe { w.bits(2) });
 
-        // Set prescaler to 4 == 1MHz timer
-        timer.prescaler.write(|w| unsafe { w.bits(4) });
+                    // Set prescaler to 4 == 1MHz timer
+                    timer.prescaler.write(|w| unsafe { w.bits(4) });
 
-        Delay { timer }
-    }
+                    Delay { timer }
+                }
 
-    pub fn free(self) -> TIMER0 {
-        self.timer
-    }
+                pub fn free(self) -> $TIM {
+                    self.timer
+                }
+            }
+
+            impl DelayMs<u32> for Delay<$TIM> {
+                fn delay_ms(&mut self, ms: u32) {
+                    self.delay_us(ms * 1_000);
+                }
+            }
+
+            impl DelayMs<u16> for Delay<$TIM> {
+                fn delay_ms(&mut self, ms: u16) {
+                    self.delay_ms(u32(ms));
+                }
+            }
+
+            impl DelayMs<u8> for Delay<$TIM> {
+                fn delay_ms(&mut self, ms: u8) {
+                    self.delay_ms(u32(ms));
+                }
+            }
+
+            impl DelayUs<u32> for Delay<$TIM> {
+                fn delay_us(&mut self, us: u32) {
+                    /* Clear event in case it was used before */
+                    self.timer.events_compare[0].write(|w| unsafe { w.bits(0) });
+
+                    /* Program counter compare register with value */
+                    self.timer.cc[0].write(|w| unsafe { w.bits(us) });
+
+                    /* Clear current counter value */
+                    self.timer.tasks_clear.write(|w| unsafe { w.bits(1) });
+
+                    /* Start counting */
+                    self.timer.tasks_start.write(|w| unsafe { w.bits(1) });
+
+                    /* Busy wait for event to happen */
+                    while self.timer.events_compare[0].read().bits() == 0 {}
+
+                    /* Stop counting */
+                    self.timer.tasks_stop.write(|w| unsafe { w.bits(1) });
+                }
+            }
+
+            impl DelayUs<u16> for Delay<$TIM> {
+                fn delay_us(&mut self, us: u16) {
+                    self.delay_us(u32(us))
+                }
+            }
+
+            impl DelayUs<u8> for Delay<$TIM> {
+                fn delay_us(&mut self, us: u8) {
+                    self.delay_us(u32(us))
+                }
+            }
+
+        )+
+    };
 }
 
-impl DelayMs<u32> for Delay {
-    fn delay_ms(&mut self, ms: u32) {
-        self.delay_us(ms * 1_000);
-    }
-}
-
-impl DelayMs<u16> for Delay {
-    fn delay_ms(&mut self, ms: u16) {
-        self.delay_ms(u32(ms));
-    }
-}
-
-impl DelayMs<u8> for Delay {
-    fn delay_ms(&mut self, ms: u8) {
-        self.delay_ms(u32(ms));
-    }
-}
-
-impl DelayUs<u32> for Delay {
-    fn delay_us(&mut self, us: u32) {
-        /* Clear event in case it was used before */
-        self.timer.events_compare[0].write(|w| unsafe { w.bits(0) });
-
-        /* Program counter compare register with value */
-        self.timer.cc[0].write(|w| unsafe { w.bits(us) });
-
-        /* Clear current counter value */
-        self.timer.tasks_clear.write(|w| unsafe { w.bits(1) });
-
-        /* Start counting */
-        self.timer.tasks_start.write(|w| unsafe { w.bits(1) });
-
-        /* Busy wait for event to happen */
-        while self.timer.events_compare[0].read().bits() == 0 {}
-
-        /* Stop counting */
-        self.timer.tasks_stop.write(|w| unsafe { w.bits(1) });
-    }
-}
-
-impl DelayUs<u16> for Delay {
-    fn delay_us(&mut self, us: u16) {
-        self.delay_us(u32(us))
-    }
-}
-
-impl DelayUs<u8> for Delay {
-    fn delay_us(&mut self, us: u8) {
-        self.delay_us(u32(us))
-    }
+delay! {
+    TIMER0,
+    TIMER1,
+    TIMER2
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -5,48 +5,62 @@ use void::Void;
 
 use hal::timer::{CountDown, Periodic};
 use nb::{Error, Result};
-use nrf51::TIMER0;
+use nrf51::{TIMER0, TIMER1, TIMER2};
 
-pub struct Timer(TIMER0);
-
-impl Timer {
-    pub fn new(timer: TIMER0) -> Timer {
-        // 32bits @ 1MHz == max delay of ~1 hour 11 minutes
-        timer.bitmode.write(|w| w.bitmode()._32bit());
-        timer.prescaler.write(|w| unsafe { w.prescaler().bits(4) });
-        timer.intenset.write(|w| w.compare0().set());
-        timer.shorts.write(|w| w.compare0_clear().enabled());
-
-        Timer(timer)
-    }
+pub struct Timer<TIM> {
+    timer: TIM,
 }
 
-impl CountDown for Timer {
-    type Time = Duration;
+macro_rules! timer {
+    ($($TIM:ty),+) => {
+        $(
+            impl Timer<$TIM> {
+                pub fn new(timer: $TIM) -> Self {
+                    // 32bits @ 1MHz == max delay of ~1 hour 11 minutes
+                    timer.bitmode.write(|w| w.bitmode()._32bit());
+                    timer.prescaler.write(|w| unsafe { w.prescaler().bits(4) });
+                    timer.intenset.write(|w| w.compare0().set());
+                    timer.shorts.write(|w| w.compare0_clear().enabled());
 
-    fn start<T>(&mut self, count: T)
-    where
-        T: Into<Self::Time>,
-    {
-        let duration = count.into();
-        assert!(duration.as_secs() < ((u32::MAX - duration.subsec_micros()) / 1_000_000) as u64);
+                    Timer { timer: timer }
+                }
+            }
 
-        let us = (duration.as_secs() as u32) * 1_000_000 + duration.subsec_micros();
-        self.0.cc[0].write(|w| unsafe { w.bits(us) });
+            impl CountDown for Timer<$TIM> {
+                type Time = Duration;
 
-        self.0.events_compare[0].reset();
-        self.0.tasks_clear.write(|w| unsafe { w.bits(1) });
-        self.0.tasks_start.write(|w| unsafe { w.bits(1) });
-    }
+                fn start<T>(&mut self, count: T)
+                where
+                    T: Into<Self::Time>,
+                {
+                    let duration = count.into();
+                    assert!(duration.as_secs() < ((u32::MAX - duration.subsec_micros()) / 1_000_000) as u64);
 
-    fn wait(&mut self) -> Result<(), Void> {
-        if self.0.events_compare[0].read().bits() == 1 {
-            self.0.events_compare[0].reset();
-            Ok(())
-        } else {
-            Err(Error::WouldBlock)
-        }
-    }
+                    let us = (duration.as_secs() as u32) * 1_000_000 + duration.subsec_micros();
+                    self.timer.cc[0].write(|w| unsafe { w.bits(us) });
+
+                    self.timer.events_compare[0].reset();
+                    self.timer.tasks_clear.write(|w| unsafe { w.bits(1) });
+                    self.timer.tasks_start.write(|w| unsafe { w.bits(1) });
+                }
+
+                fn wait(&mut self) -> Result<(), Void> {
+                    if self.timer.events_compare[0].read().bits() == 1 {
+                        self.timer.events_compare[0].reset();
+                        Ok(())
+                    } else {
+                        Err(Error::WouldBlock)
+                    }
+                }
+            }
+
+            impl Periodic for Timer<$TIM> {}
+        )+
+    };
 }
 
-impl Periodic for Timer {}
+timer!{
+    TIMER0,
+    TIMER1,
+    TIMER2
+}


### PR DESCRIPTION
TIMER1 and TIMER2 can now be used for this functionality instead of just
TIMER0. This can be useful for constructing multiple `Delay`s at once (for example, in a multi-app scenario).